### PR TITLE
Allow colons in file paths

### DIFF
--- a/go-spatial.go
+++ b/go-spatial.go
@@ -127,7 +127,7 @@ func main() {
 		if len(toolArgs) > 0 {
 			// parse the args
 			f := func(c rune) bool {
-				return !unicode.IsLetter(c) && !unicode.IsNumber(c) && c != '.' && c != os.PathSeparator && c != ' ' && c != '-' && c != '_'
+				return !unicode.IsLetter(c) && !unicode.IsNumber(c) && c != '.' && c != os.PathSeparator && c != ' ' && c != '-' && c != '_' && c != ':'
 			}
 			argsArray = strings.FieldsFunc(toolArgs, f)
 		}
@@ -272,7 +272,7 @@ func init() {
 			s = strings.TrimSpace(s)
 			// parse the args
 			f := func(c rune) bool {
-				return !unicode.IsLetter(c) && !unicode.IsNumber(c) && c != '.' && c != os.PathSeparator && c != ' ' && c != '-'
+				return !unicode.IsLetter(c) && !unicode.IsNumber(c) && c != '.' && c != os.PathSeparator && c != ' ' && c != '-' && c != '_' && c != ':'
 			}
 			argsArray := strings.FieldsFunc(s, f)
 


### PR DESCRIPTION
This commit solves the issues that in windows, supplying a full file path through command line arguments will result in a file not found error.

This problem was resolved by adding a colon to the list no non-delimiting characters.